### PR TITLE
Fix for new parallelization scheme.

### DIFF
--- a/.github/workflows/fix-ci.yml
+++ b/.github/workflows/fix-ci.yml
@@ -9,8 +9,9 @@ jobs:
     name: Fix the entries of BioModels and commit to the repository
     strategy:
       matrix:
-          job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 18, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
-    runs-on: ubuntu-latest
+#          job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 18, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
+           job: [0, 1, 2]
+   runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -84,7 +85,7 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Fix entries
-        run: python fix-entries.py --convert-files --validate-sbml --num-jobs 40 --job ${{ matrix.job }}
+        run: python fix-entries.py --convert-files --validate-sbml --num-jobs 40 --job ${{ matrix.job * 40}}
 
       - name: Setup Git
         run: |

--- a/fix-entries.py
+++ b/fix-entries.py
@@ -75,15 +75,13 @@ def fix_entries(ids, convert_files=False, guess_file_name=None, validate_sbml=Fa
     if parallel:
         if processes is None:
             processes = os.cpu_count()
-        _fix_entry_func = functools.partial(_fix_entry, convert_files=convert_files,
-                                            guess_file_name=guess_file_name, validate_sbml=validate_sbml, display_warnings=display_warnings)
+        _fix_entry_func = functools.partial(_fix_entry, convert_files=convert_files, guess_file_name=guess_file_name, validate_sbml=validate_sbml, display_warnings=display_warnings)
         with multiprocessing.Pool(processes=processes) as pool:
             pool.map(_fix_entry_func, ids)
         print('done')
     else:
         for id in ids:
-            _fix_entry(id, convert_files=convert_files, guess_file_name=guess_file_name,
-                       validate_sbml=validate_sbml, display_warnings=display_warnings)
+            _fix_entry(id, convert_files=convert_files, guess_file_name=guess_file_name, validate_sbml=validate_sbml, display_warnings=display_warnings)
 
 
 def _fix_entry(id, convert_files=False, guess_file_name=None, validate_sbml=False, display_warnings=True):
@@ -304,24 +302,24 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        '--num-jobs',
-        help='Amount of parallelism.',
-        default=1,
-        type=int,
+            '--num-jobs',
+            help='Amount of parallelism.',
+            default=1,
+            type=int,
     )
 
     parser.add_argument(
-        '--job',
-        help='Index of job within "--num-jobs" to execute',
-        default=0,
-        type=int,
+            '--job',
+            help='Index of job within "--num-jobs" to execute',
+            default=0,
+            type=int,
     )
 
     args = parser.parse_args()
     if args.entry_ids:
         ids = args.entry_ids
     else:
-        ids = get_entry_ids()[args.job:args.num_jobs:min(args.max_entries)]
+        ids = get_entry_ids()[args.job:args.num_jobs:args.max_entries]
 
     low_ids = []
     if args.first_entry:
@@ -334,8 +332,7 @@ if __name__ == "__main__":
     guess_file_name = "guesses.csv"
     #args.convert_files = True
     #args.validate_sbml = True
-    fix_entries(ids, convert_files=args.convert_files, guess_file_name=guess_file_name, validate_sbml=args.validate_sbml,
-                display_warnings=not args.do_not_display_warnings, processes=args.processes, parallel=args.parallel)
+    fix_entries(ids, convert_files=args.convert_files, guess_file_name=guess_file_name, validate_sbml=args.validate_sbml, display_warnings=not args.do_not_display_warnings, processes=args.processes, parallel=args.parallel)
 
     if args.validate_sbml:
         err_file = open("sbml_validation.csv", "w")


### PR DESCRIPTION
The current scheme runs models 0-40 in one thread, models 1-41 in another, etc.  I have no idea if you can use math in this way for the github workflows, so this is an experiment.

The next problem to solve will be only committing the 'final/' models that were actually changed, but let's see if the first thing works first.

Reduce number of jobs running at once while testing.