### PR TITLE
Use newest pip

### DIFF
--- a/.github/workflows/fix-ci.yml
+++ b/.github/workflows/fix-ci.yml
@@ -32,11 +32,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install pip and setuptools
-        run: |
-          python -m pip install pip==23.0.0
-          python -m pip install pip==23.0.0
-
       - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'


### PR DESCRIPTION
We've pinned everything to an old pip for yonks, because the way we set things up was incompatible with the newer version.  But now the CI won't let us install the old version any more; we need to actually fix things.